### PR TITLE
Explicity use C90 standard

### DIFF
--- a/04-HeyMac/CMakeLists.txt
+++ b/04-HeyMac/CMakeLists.txt
@@ -7,3 +7,6 @@ add_application("Hey"
 # Enable -ffunction-sections and -gc-sections to make the app as small as possible
 set_target_properties("Hey" PROPERTIES COMPILE_OPTIONS -ffunction-sections)
 set_target_properties("Hey" PROPERTIES LINK_FLAGS "-Wl,-gc-sections")
+
+# This is old code (K&R function definitions, etc.), tell the compiler so for good measure
+set_target_properties("Hey" PROPERTIES C_STANDARD 90)

--- a/06-MiniGenApp/CMakeLists.txt
+++ b/06-MiniGenApp/CMakeLists.txt
@@ -18,3 +18,6 @@ add_application(MiniGeneric
 # Enable -ffunction-sections and -gc-sections to make the app as small as possible
 set_target_properties(MiniGeneric PROPERTIES COMPILE_OPTIONS -ffunction-sections)
 set_target_properties(MiniGeneric PROPERTIES LINK_FLAGS "-Wl,-gc-sections")
+
+# This is old code (K&R function definitions, etc.), tell the compiler so for good measure
+set_target_properties(MiniGeneric PROPERTIES C_STANDARD 90)

--- a/07-MultiGenApp/CMakeLists.txt
+++ b/07-MultiGenApp/CMakeLists.txt
@@ -18,3 +18,6 @@ add_application(MultiGeneric
 # Enable -ffunction-sections and -gc-sections to make the app as small as possible
 set_target_properties(MultiGeneric PROPERTIES COMPILE_OPTIONS -ffunction-sections)
 set_target_properties(MultiGeneric PROPERTIES LINK_FLAGS "-Wl,-gc-sections")
+
+# This is old code (K&R function definitions, etc.), tell the compiler so for good measure
+set_target_properties(MultiGeneric PROPERTIES C_STANDARD 90)

--- a/08-NonGenApp/CMakeLists.txt
+++ b/08-NonGenApp/CMakeLists.txt
@@ -18,3 +18,6 @@ add_application(NonGenApp
 # Enable -ffunction-sections and -gc-sections to make the app as small as possible
 set_target_properties(NonGenApp PROPERTIES COMPILE_OPTIONS -ffunction-sections)
 set_target_properties(NonGenApp PROPERTIES LINK_FLAGS "-Wl,-gc-sections")
+
+# This is old code (K&R function definitions, etc.), tell the compiler so for good measure
+set_target_properties(NonGenApp PROPERTIES C_STANDARD 90)

--- a/09-Loser/CMakeLists.txt
+++ b/09-Loser/CMakeLists.txt
@@ -13,3 +13,6 @@ add_application(Loser
 # Enable -ffunction-sections and -gc-sections to make the app as small as possible
 set_target_properties(Loser PROPERTIES COMPILE_OPTIONS -ffunction-sections)
 set_target_properties(Loser PROPERTIES LINK_FLAGS "-Wl,-gc-sections")
+
+# This is old code (K&R function definitions, etc.), tell the compiler so for good measure
+set_target_properties(Loser PROPERTIES C_STANDARD 90)

--- a/11-Browser/CMakeLists.txt
+++ b/11-Browser/CMakeLists.txt
@@ -21,3 +21,6 @@ add_application(Browser
 # Enable -ffunction-sections and -gc-sections to make the app as small as possible
 set_target_properties(Browser PROPERTIES COMPILE_OPTIONS -ffunction-sections)
 set_target_properties(Browser PROPERTIES LINK_FLAGS "-Wl,-gc-sections")
+
+# This is old code (K&R function definitions, etc.), tell the compiler so for good measure
+set_target_properties(Browser PROPERTIES C_STANDARD 90)


### PR DESCRIPTION
Per #1, K&R-style function definitions are deprecated and will be removed from a future C standard. To cover our bases, explicitly request C90 features from the compiler.